### PR TITLE
change post url

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,11 +14,11 @@ description: GSoC progress
 # Your name to show in the footer
 author: Chandan Kumar
 
-url: https://github.com/TheRoboticsClub/gsoc2021-Chandan_Kumar
+url: "https://theroboticsclub.github.io/gsoc2021-Chandan_Kumar"
 # --- List of links in the navigation bar --- #
 
 navbar-links:
-  Home: https://github.com/TheRoboticsClub/gsoc2021-Chandan_Kumar
+  Home: "https://theroboticsclub.github.io/gsoc2021-Chandan_Kumar"
   About Me: "aboutme"
   Resources:
     - Introduction: "aboutproject"


### PR DESCRIPTION
The url setting for posts should be `"https://theroboticsclub.github.io/gsoc2021-Chandan_Kumar"` instead of `https://github.com/TheRoboticsClub/gsoc2021-Chandan_Kumar`